### PR TITLE
Extends io trace by filesystem extension

### DIFF
--- a/source/octf/interface/internal/TraceJob.cpp
+++ b/source/octf/interface/internal/TraceJob.cpp
@@ -148,7 +148,10 @@ void TraceJob::serialize(const void *data, uint32_t size) {
     bool serialized = false;
     if (m_converter) {
         auto protoBuffer = m_converter->convertTrace(data, size);
-        serialized = m_serializer->serialize(protoBuffer);
+
+        if (protoBuffer) {
+            serialized = m_serializer->serialize(protoBuffer);
+        }
     } else {
         serialized = m_serializer->serialize(data, size);
     }

--- a/source/octf/proto/trace.proto
+++ b/source/octf/proto/trace.proto
@@ -65,6 +65,33 @@ message EventIo {
     bool fua = 7;
 }
 
+/**
+ * @brief IO trace event metadata (e.g. filesystem meta information)
+ *
+ * If an application works on top of a filesystem it may perform IO operations
+ * to files. This structure contains meta information about IO in domain of
+ * filesystem. For example it provides information about file size,
+ * file offset of IO, etc.
+ */
+message EventIoFilesystemMeta {
+    /**
+     * Event sequence ID reference to IO trace event associated with this event
+     */
+    uint64 refSid = 1;
+
+    /** File ID */
+    uint64 fileId = 2;
+
+    /** File parent ID */
+    uint64 fileParentId = 3;
+
+    /** File offset in sectors */
+    uint64 fileOffset = 4;
+
+    /** File size in sectors */
+    uint64 fileSize = 5;
+};
+
 message Event {
     /** Trace event header */
     EventHeader header = 1;
@@ -72,5 +99,6 @@ message Event {
     oneof EventType {
         EventIo io = 2;
         EventDeviceDescription deviceDescription = 3;
+        EventIoFilesystemMeta filesystemMeta = 4;
     }
 }

--- a/source/octf/trace/iotrace_event.h
+++ b/source/octf/trace/iotrace_event.h
@@ -5,7 +5,6 @@
 
 #ifndef SOURCE_OCTF_TRACE_IOTRACE_EVENT_H
 #define SOURCE_OCTF_TRACE_IOTRACE_EVENT_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +32,9 @@ typedef enum {
 
     /** IO queue event */
     iotrace_event_type_io = 'Q',
+
+    /** IO queue event */
+    iotrace_event_type_fs_meta = 'F',
 } iotrace_event_type;
 
 /**
@@ -129,8 +131,37 @@ struct iotrace_event {
     uint32_t flags;
 } __attribute__((packed, aligned(8)));
 
+/**
+ * @brief IO trace event metadata (e.g. filesystem meta information)
+ *
+ * If an application works on top of a filesystem it may perform IO operations
+ * to files. This structure contains meta information about IO in domain of
+ * filesystem. For example it provides information about file size,
+ * file offset of IO, etc.
+ */
+struct iotrace_event_fs_meta {
+    /** Trace event header */
+    struct iotrace_event_hdr hdr;
+
+    /**
+     * Event sequence ID reference to IO trace event associated with this event
+     */
+    log_sid_t ref_sid;
+
+    /** File ID */
+    uint64_t file_id;
+
+    /** File parent ID */
+    uint64_t file_parent_id;
+
+    /** File offset in sectors */
+    uint64_t file_offset;
+
+    /** File size in sectors */
+    uint64_t file_size;
+} __attribute__((packed, aligned(8)));
+
 #ifdef __cplusplus
 }
 #endif
-
 #endif  // SOURCE_OCTF_TRACE_IOTRACE_EVENT_H

--- a/source/octf/trace/iotrace_event.h
+++ b/source/octf/trace/iotrace_event.h
@@ -6,6 +6,16 @@
 #ifndef SOURCE_OCTF_TRACE_IOTRACE_EVENT_H
 #define SOURCE_OCTF_TRACE_IOTRACE_EVENT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
+#include <stdint.h>
+#endif
+
 typedef uint64_t log_sid_t;
 
 #define IOTRACE_EVENT_VERSION_MAJOR 1
@@ -118,5 +128,9 @@ struct iotrace_event {
      * are summed (OR-ed) together. */
     uint32_t flags;
 } __attribute__((packed, aligned(8)));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // SOURCE_OCTF_TRACE_IOTRACE_EVENT_H


### PR DESCRIPTION
Extends IO trace event declaration.

It adds trace event filesystem extension which contains filesystem meta information.