### PR TITLE
Fixes InterfaceTraceCreatingImpl keeping references for node path

### DIFF
--- a/source/octf/interface/InterfaceTraceCreatingImpl.h
+++ b/source/octf/interface/InterfaceTraceCreatingImpl.h
@@ -61,7 +61,7 @@ private:
                                 const ::google::protobuf::Descriptor *);
 
     std::unique_ptr<TraceManager> m_traceManager;
-    const NodePath &m_ownerNodePath;
+    const NodePath m_ownerNodePath;
 };
 }  // namespace octf
 

--- a/source/octf/interface/TraceManager.h
+++ b/source/octf/interface/TraceManager.h
@@ -145,7 +145,7 @@ private:
     /**
      * @brief Node path to owner node
      */
-    const NodePath &m_ownerNodePath;
+    const NodePath m_ownerNodePath;
     /**
      * @brief Module implementing start/stop trace functions
      */


### PR DESCRIPTION
Fixes InterfaceTraceCreatingImpl which kept references for node path instead of object copy

Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>