### PR TITLE
Provides IO trace events handler to work with parsed IO

### DIFF
--- a/source/octf/proto/CMakeLists.txt
+++ b/source/octf/proto/CMakeLists.txt
@@ -13,7 +13,7 @@ set(protoList
 	trace.proto
 	parsedTrace.proto
 	traceDefinitions.proto
-	)
+)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER ${protoList})
 add_library(protooctf OBJECT ${PROTO_HEADER} ${PROTO_SRC})
 target_include_directories(protooctf

--- a/source/octf/proto/CMakeLists.txt
+++ b/source/octf/proto/CMakeLists.txt
@@ -11,6 +11,7 @@ set(protoList
 	opts.proto
 	packets.proto
 	trace.proto
+	parsedTrace.proto
 	traceDefinitions.proto
 	)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER ${protoList})

--- a/source/octf/proto/parsedTrace.proto
+++ b/source/octf/proto/parsedTrace.proto
@@ -1,0 +1,70 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+syntax = "proto3";
+option cc_generic_services = true;
+import "trace.proto";
+package octf.proto.trace;
+
+message ParsedEvent {
+    message IO {
+        /** Address of IO in sectors */
+        uint64 lba = 1;
+
+        /** Size of IO in sectors */
+        uint32 len = 2;
+
+        /** IO class of IO */
+        uint32 ioClass = 3;
+
+        /** Device ID */
+        uint64 deviceId = 4;
+
+        /** Operation type: read, write, trim */
+        IoType operation = 5;
+
+        /** Flush flag */
+        bool flush = 6;
+
+        /** FUA flag */
+        bool fua = 7;
+
+        /** Flags indicates if IO ended with an error */
+        bool error = 10000;
+
+        /** IO Latency */
+        uint64 latency = 10001;
+
+        /** IO queue depth */
+        uint64 qd = 10002;
+    }
+
+    message DeviceInfo {
+        /** Device Name */
+        string name = 2;
+    }
+
+    message FileInfo {
+        /** File ID */
+        uint64 id = 2;
+
+        /** File offset in sectors */
+        uint64 offset = 4;
+
+        /** File size in sectors */
+        uint64 size = 5;
+    }
+
+    /** Header Information */
+    EventHeader header = 1;
+
+    /** IO Basic Information */
+    IO io = 2;
+
+    /** Device Information */
+    DeviceInfo device = 3;
+
+    /** File Information */
+    FileInfo file = 4;
+}

--- a/source/octf/proto/parsedTrace.proto
+++ b/source/octf/proto/parsedTrace.proto
@@ -3,10 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 syntax = "proto3";
-option cc_generic_services = true;
 import "trace.proto";
 package octf.proto.trace;
 
+/**
+ * The parsed IO contains basic IO information (LBA, length, etc). It is
+ * supplemented by related information like filesystem one. In addition it
+ * provides post parse information (latency, queue depth, etc...).
+ */
 message ParsedEvent {
     message IO {
         /** Address of IO in sectors */
@@ -18,9 +22,6 @@ message ParsedEvent {
         /** IO class of IO */
         uint32 ioClass = 3;
 
-        /** Device ID */
-        uint64 deviceId = 4;
-
         /** Operation type: read, write, trim */
         IoType operation = 5;
 
@@ -29,6 +30,9 @@ message ParsedEvent {
 
         /** FUA flag */
         bool fua = 7;
+
+        /** Reserve not presented fields of EventIo */
+        reserved 4;
 
         /** Flags indicates if IO ended with an error */
         bool error = 10000;
@@ -41,8 +45,14 @@ message ParsedEvent {
     }
 
     message DeviceInfo {
+        /** Device ID */
+        uint64 id = 1;
+
         /** Device Name */
         string name = 2;
+
+        /** Reserve not presented fields of EventDeviceDescription */
+        reserved 3;
     }
 
     message FileInfo {
@@ -54,6 +64,9 @@ message ParsedEvent {
 
         /** File size in sectors */
         uint64 size = 5;
+
+        /** Reserve not presented fields of EventIoFilesystemMeta */
+        reserved 1, 3;
     }
 
     /** Header Information */

--- a/source/octf/trace/parser/CMakeLists.txt
+++ b/source/octf/trace/parser/CMakeLists.txt
@@ -1,13 +1,13 @@
 target_sources(octf
 PRIVATE
-	${CMAKE_CURRENT_LIST_DIR}/ITraceParser.h
-	${CMAKE_CURRENT_LIST_DIR}/TraceFileParser.cpp
-	${CMAKE_CURRENT_LIST_DIR}/TraceFileReader.h
-	${CMAKE_CURRENT_LIST_DIR}/TraceFileParser.h
-	${CMAKE_CURRENT_LIST_DIR}/TraceFileReader.cpp
-	${CMAKE_CURRENT_LIST_DIR}/TraceEventHandler.h
-	${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandlerJsonPrinter.h
-	${CMAKE_CURRENT_LIST_DIR}/TraceEventHandlerJsonPrinter.h
+    ${CMAKE_CURRENT_LIST_DIR}/ITraceParser.h
+    ${CMAKE_CURRENT_LIST_DIR}/TraceFileParser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/TraceFileReader.h
+    ${CMAKE_CURRENT_LIST_DIR}/TraceFileParser.h
+    ${CMAKE_CURRENT_LIST_DIR}/TraceFileReader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/TraceEventHandler.h
+    ${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandlerJsonPrinter.h
+    ${CMAKE_CURRENT_LIST_DIR}/TraceEventHandlerJsonPrinter.h
     ${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandler.h
     ${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandler.cpp
 )

--- a/source/octf/trace/parser/CMakeLists.txt
+++ b/source/octf/trace/parser/CMakeLists.txt
@@ -8,4 +8,6 @@ PRIVATE
 	${CMAKE_CURRENT_LIST_DIR}/TraceEventHandler.h
 	${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandlerJsonPrinter.h
 	${CMAKE_CURRENT_LIST_DIR}/TraceEventHandlerJsonPrinter.h
+    ${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandler.h
+    ${CMAKE_CURRENT_LIST_DIR}/IoTraceEventHandler.cpp
 )

--- a/source/octf/trace/parser/IoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/IoTraceEventHandler.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include <octf/trace/parser/IoTraceEventHandler.h>
+
+namespace octf {
+
+IoTraceEventHandler::IoTraceEventHandler(const std::string &tracePath)
+        : TraceEventHandler<proto::trace::Event>(tracePath)
+        , m_cache()
+        , m_devices()
+        , m_timestampOffset(0)
+        , m_ioQueueDepth(0) {}
+
+void IoTraceEventHandler::handleEvent(
+        std::shared_ptr<proto::trace::Event> traceEvent) {
+    using namespace proto::trace;
+    auto timestamp = traceEvent->mutable_header()->timestamp();
+    if (!m_timestampOffset) {
+        // This event handler presents traces from time '0', we remember
+        // first event timestamp and subtract by this value for each event
+        m_timestampOffset = timestamp;
+    }
+    traceEvent->mutable_header()->set_timestamp(timestamp - m_timestampOffset);
+
+    switch (traceEvent->EventType_case()) {
+    case Event::EventTypeCase::kDeviceDescription: {
+        // Remember device
+        auto device = traceEvent->mutable_devicedescription();
+        m_devices[device->id()] = *device;
+    } break;
+
+    case Event::EventTypeCase::kIo: {
+        auto sid = traceEvent->mutable_header()->sid();
+        auto device = traceEvent->io().deviceid();
+        // Allocate new parsed IO event in the cache
+        auto &cachedEvent = m_cache[sid];
+        cachedEvent.mutable_header()->CopyFrom(traceEvent->header());
+
+        {
+            auto &dst = *cachedEvent.mutable_io();
+            const auto &src = traceEvent->io();
+
+            dst.set_lba(src.lba());
+            dst.set_len(src.len());
+            dst.set_ioclass(src.ioclass());
+            dst.set_deviceid(src.deviceid());
+            dst.set_operation(src.operation());
+            dst.set_flush(src.flush());
+            dst.set_fua(src.fua());
+
+            dst.set_qd(++m_ioQueueDepth);
+        }
+
+        cachedEvent.mutable_device()->set_name(m_devices[device].name());
+    } break;
+
+    case Event::EventTypeCase::kIoCompletion: {
+        if (m_ioQueueDepth) {
+            m_ioQueueDepth--;
+        }
+
+        auto lba = traceEvent->mutable_iocompletion()->lba();
+        auto len = traceEvent->mutable_iocompletion()->len();
+        auto timestamp = traceEvent->mutable_header()->timestamp();
+        auto sid = traceEvent->mutable_header()->sid();
+        auto error = traceEvent->mutable_iocompletion()->error();
+        // Find in cache which IO has been completed. We match by LBA and
+        // length
+        auto iter = m_cache.begin();
+        auto end = m_cache.end();
+        for (; iter != end; ++iter) {
+            if (iter->first > sid) {
+                // Iterating over higher SID, what means over never event,
+                // so
+                break;
+            }
+
+            if (iter->second.mutable_io()->lba() == lba &&
+                iter->second.mutable_io()->len() == len) {
+                uint64_t latency =
+                        timestamp - iter->second.mutable_header()->timestamp();
+
+                // IO found, set latency and result of IO
+                iter->second.mutable_io()->set_latency(latency);
+                iter->second.mutable_io()->set_error(error);
+
+                break;
+            }
+        }
+        flushEvetns();
+    } break;
+
+    case Event::kFilesystemMeta: {
+        auto sid = traceEvent->mutable_filesystemmeta()->refsid();
+
+        auto iter = m_cache.find(sid);
+        if (iter != m_cache.end()) {
+            auto &dst = *iter->second.mutable_file();
+            const auto &src = *traceEvent->mutable_filesystemmeta();
+            dst.set_id(src.fileid());
+            dst.set_offset(src.fileoffset());
+            dst.set_size(src.filesize());
+        }
+    } break;
+
+    default: { } break; }
+}
+
+std::shared_ptr<proto::trace::Event>
+IoTraceEventHandler::getEventMessagePrototype() {
+    return std::make_shared<proto::trace::Event>();
+}
+
+void IoTraceEventHandler::flushEvetns() {
+    auto iter = m_cache.begin();
+    auto end = m_cache.end();
+    for (; iter != end;) {
+        if (iter->second.mutable_io()->latency()) {
+            handleIO(iter->second);
+            iter = m_cache.erase(iter);
+        } else {
+            break;
+        }
+    }
+
+    // If IO traces cache exceed some number, or all parser finished its job,
+    // flush IOs
+    constexpr uint64_t cacheLimit = 1000 * 1000;
+    while (m_cache.size() > cacheLimit || getParser()->isFinished()) {
+        handleIO(m_cache.begin()->second);
+        m_cache.erase(m_cache.begin());
+
+        if (0 == m_cache.size()) {
+            break;
+        }
+    }
+}
+
+}  // namespace octf

--- a/source/octf/trace/parser/IoTraceEventHandler.h
+++ b/source/octf/trace/parser/IoTraceEventHandler.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef SOURCE_OCTF_TRACE_PARSER_IOTRACEEVENTHANDLER_H
+#define SOURCE_OCTF_TRACE_PARSER_IOTRACEEVENTHANDLER_H
+
+#include <map>
+#include <memory>
+#include <octf/proto/parsedTrace.pb.h>
+#include <octf/proto/trace.pb.h>
+#include <octf/trace/parser/TraceEventHandler.h>
+
+namespace octf {
+
+/**
+ * This is IO trace event handler of parsed IO
+ *
+ * The parsed IO contains basic IO information (LBA, length, etc). It is
+ * supplemented by related information like filesystem one. In addition it
+ * provides post parse information (latency, queue depth, etc...).
+ */
+class IoTraceEventHandler : public TraceEventHandler<proto::trace::Event> {
+public:
+    IoTraceEventHandler(const std::string &tracePath);
+    virtual ~IoTraceEventHandler() = default;
+
+    /**
+     * Handles parsed IO
+     *
+     * @param io Parsed IO to be handle
+     */
+    virtual void handleIO(proto::trace::ParsedEvent &io) = 0;
+
+private:
+    bool compareEvents(const proto::trace::Event *a,
+                       const proto::trace::Event *b) override {
+        return a->header().sid() < b->header().sid();
+    }
+
+    void handleEvent(std::shared_ptr<proto::trace::Event> traceEvent);
+
+    virtual std::shared_ptr<proto::trace::Event> getEventMessagePrototype()
+            override;
+
+    void flushEvetns();
+
+private:
+    typedef proto::trace::ParsedEvent ParsedEvent;
+    std::map<uint64_t, ParsedEvent> m_cache;
+    std::map<uint64_t, proto::trace::EventDeviceDescription> m_devices;
+    uint64_t m_timestampOffset;
+    uint64_t m_ioQueueDepth;
+};
+
+}  // namespace octf
+
+#endif  // SOURCE_OCTF_TRACE_PARSER_IOTRACEEVENTHANDLER_H


### PR DESCRIPTION
The parsed IO contains basic IO information (LBA, length, etc).
It is supplemented by related information like filesystem one.
In addition it provides post parse information (latency,
queue depth, etc...)

Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>