### PR TITLE
Flushes left IO when parsed trace event handler ended

### DIFF
--- a/source/octf/trace/parser/ParsedIoTraceEventHandler.h
+++ b/source/octf/trace/parser/ParsedIoTraceEventHandler.h
@@ -37,6 +37,11 @@ public:
      */
     virtual void handleIO(proto::trace::ParsedEvent &io) = 0;
 
+    void processEvents() override {
+        TraceEventHandler<proto::trace::Event>::processEvents();
+        flushEvents();
+    }
+
 private:
     bool compareEvents(const proto::trace::Event *a,
                        const proto::trace::Event *b) override {

--- a/source/octf/trace/parser/ParsedIoTraceEventHandlerPrinter.cpp
+++ b/source/octf/trace/parser/ParsedIoTraceEventHandlerPrinter.cpp
@@ -42,7 +42,7 @@ void ParsedIoTraceEventHandlerPrinter::processEvents() {
         table::setHeader(m_table[0], &event);
         std::cout << m_table << std::endl;
     }
-    TraceEventHandler<proto::trace::Event>::processEvents();
+    ParsedIoTraceEventHandler::processEvents();
 }
 
 }  // namespace octf


### PR DESCRIPTION
Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>