### PR TITLE
Made cmake path variables global (cache internal) in buildsystem

### DIFF
--- a/octf-paths.cmake
+++ b/octf-paths.cmake
@@ -17,6 +17,7 @@ foreach(dir ${DIRS})
 
     # Remove double backslashes etc.
     get_filename_component(${dir} ${${dir}} REALPATH)
+    set(${dir} ${${dir}} CACHE INTERNAL ${dir})
 endforeach(dir)
 
 set(configFileName "octf.conf")


### PR DESCRIPTION
Signed-off-by: Tomasz Rybicki <tomasz.rybicki@intel.com>