### PR TITLE
Add path length for detecting maximum recursion

### DIFF
--- a/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
@@ -8,6 +8,7 @@
 #include <list>
 #include <map>
 #include <octf/utils/Exception.h>
+#include <octf/utils/Log.h>
 #include <octf/utils/NonCopyable.h>
 #include <limits.h>
 
@@ -624,7 +625,12 @@ public:
 
         auto iter = m_fileInfo.find(fid);
         if (iter != m_fileInfo.end()) {
-            getPath(iter->second.parentId, dir, len);
+            try {
+                getPath(iter->second.parentId, dir, len);
+            }
+            catch (MaxPathExceededException &e) {
+                log::cerr << e.getMessage() << std::endl;
+            }
         }
 
         return dir;
@@ -672,7 +678,7 @@ private:
             const auto &info = iter->second;
             len += info.name.length();
             if (len > PATH_MAX) {
-                throw Exception("Exceeded maximum path length limit");
+                throw MaxPathExceededException(id);
             }
             if (id != info.parentId) {
                 if (!getPath(info.parentId, path, len)) {

--- a/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
@@ -428,6 +428,7 @@ void ParsedIoTraceEventHandler::handleEvent(
     case Event::EventTypeCase::kFilesystemFileEvent: {
         const auto &fsEvent = traceEvent->filesystemfileevent();
         auto partId = fsEvent.partitionid();
+        FileId file = FileId(fsEvent);
 
         // Allocate new parsed IO event in the queue
         m_queue.emplace(ParsedEvent());
@@ -448,8 +449,11 @@ void ParsedIoTraceEventHandler::handleEvent(
         destDevInfo.set_partition(partId);
 
         // Set file size from file info
-        auto size = m_fileInfo[FileId(fsEvent)].size;
+        auto size = m_fileInfo[file].size;
         dstFileInfo.set_size(size);
+        if (fsEvent.fseventtype() == FsEventType::Delete) {
+            m_fileInfo.erase(file);
+        }
     } break;
 
     case Event::kFilesystemFileNameFieldNumber: {

--- a/source/octf/utils/Exception.h
+++ b/source/octf/utils/Exception.h
@@ -94,6 +94,17 @@ public:
 };
 
 /**
+ * @brief Exception which occurred during file system path traversing
+ */
+class MaxPathExceededException : public octf::Exception {
+public:
+    MaxPathExceededException(const uint64_t inode)
+            : Exception(std::string("Exceeded maximum path length limit for inode ") +
+                        std::to_string(inode)) {}
+    virtual ~MaxPathExceededException() = default;
+};
+
+/**
  * @}
  * @}
  */


### PR DESCRIPTION
This should allow for more graceful handling when parsing potentially damaged traces.

Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>