### PR TITLE
Unify traces description

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -156,4 +156,4 @@ file(APPEND ${CMAKE_BINARY_DIR}/octf-vars.cmake
 # Install it next to octf-config
 install(FILES ${CMAKE_BINARY_DIR}/octf-vars.cmake DESTINATION ${OCTF_PACKAGE_DIR} COMPONENT octf-install-cmake)
 
-add_subdirectory(examples)
+# add_subdirectory(examples)

--- a/source/octf/analytics/statistics/CMakeLists.txt
+++ b/source/octf/analytics/statistics/CMakeLists.txt
@@ -12,4 +12,6 @@ PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/WorksetCalculatorDevices.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FilesystemStatistics.h
     ${CMAKE_CURRENT_LIST_DIR}/FilesystemStatistics.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/FilesystemStatisticsEntry.h
+    ${CMAKE_CURRENT_LIST_DIR}/FilesystemStatisticsEntry.cpp
 )

--- a/source/octf/analytics/statistics/FilesystemStatistics.cpp
+++ b/source/octf/analytics/statistics/FilesystemStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2012-2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -8,97 +8,94 @@
 namespace octf {
 
 struct FilesystemStatistics::Key {
+    Key(uint64_t id, uint64_t size, const std::string &name)
+            : Id(id)
+            , Size(size)
+            , Name(name) {}
+    Key(uint64_t id)
+            : Id(id)
+            , Size(0)
+            , Name("") {}
     Key()
-            : name()
-            , devId()
-            , partId()
-            , statsCase(StatisticsCase::NAME_NOT_SET) {}
-
-    Key(StatisticsCase sCase,
-        const std::string &name,
-        uint64_t devId,
-        uint64_t partId)
-            : name(name)
-            , devId(devId)
-            , partId(partId)
-            , statsCase(sCase) {}
-
+            : Id()
+            , Size()
+            , Name("") {}
     virtual ~Key() {}
 
     Key(const Key &other)
-            : name(other.name)
-            , devId(other.devId)
-            , partId(other.partId)
-            , statsCase(other.statsCase) {}
+            : Id(other.Id)
+            , Size(other.Size)
+            , Name(other.Name) {}
 
     Key &operator=(const Key &other) {
         if (this != &other) {
-            name = other.name;
-            devId = other.devId;
-            partId = other.partId;
-            statsCase = other.statsCase;
+            Id = other.Id;
+            Size = other.Size;
+            Name = other.Name;
         }
 
         return *this;
     }
 
     bool operator==(const Key &other) const {
-        return name == other.name && devId == other.devId &&
-               partId == other.partId && statsCase == other.statsCase;
+        return Id == other.Id;
     }
 
     bool operator!=(const Key &other) const {
-        return !(*this == other);
+        return Id != other.Id;
     }
 
     bool operator<(const Key &other) const {
-        int result = name.compare(other.name);
-        if (0 == result) {
-            if (devId != other.devId) {
-                return devId < other.devId;
-            } else if (partId != other.partId) {
-                return partId < other.partId;
-            } else {
-                return statsCase < other.statsCase;
-            }
-        }
-
-        return result < 0;
+        return Id < other.Id;
     }
 
-    std::string name;
-    uint64_t devId;
-    uint64_t partId;
-    StatisticsCase statsCase;
+    uint64_t Id;
+    uint64_t Size;
+    std::string Name;
 };
 
 FilesystemStatistics::FilesystemStatistics()
-        : m_children()
-        , m_ioStats()
-        , m_devId()
-        , m_partId()
-        , m_statsCase(StatisticsCase::NAME_NOT_SET) {}
+        : m_map() {}
 
 FilesystemStatistics::~FilesystemStatistics() {}
 
 FilesystemStatistics::FilesystemStatistics(const FilesystemStatistics &other)
-        : m_children(other.m_children)
-        , m_ioStats(other.m_ioStats)
-        , m_devId(other.m_devId)
-        , m_partId(other.m_partId)
-        , m_statsCase(other.m_statsCase) {}
+        : m_map(other.m_map) {}
 
 FilesystemStatistics &FilesystemStatistics::operator=(
         const FilesystemStatistics &other) {
     if (&other != this) {
-        m_children = other.m_children;
-        m_ioStats = other.m_ioStats;
-        m_devId = other.m_devId;
-        m_partId = other.m_partId;
-        m_statsCase = other.m_statsCase;
+        m_map = other.m_map;
     }
 
     return *this;
+}
+
+void FilesystemStatistics::addDevice(
+        const proto::trace::EventDeviceDescription &devDesc) {
+    Key key(devDesc.id(), devDesc.size(), devDesc.name());
+
+    // Check maybe key already exists
+    auto iter = m_map.find(key);
+    if (iter != m_map.end()) {
+        // Key already exists, we have to update it, but need to keep the old
+        // copy of IO statistics
+
+        // Create pair of the updated key and the old statistics
+        auto pair = std::make_pair(Key(key), FilesystemStatisticsEntry(iter->second));
+
+        // Remove the old key
+        m_map.erase(key);
+
+        // Insert the new pair
+        auto result = m_map.emplace(pair);
+        if (!result.second || result.first == m_map.end()) {
+            throw Exception("Cannot allocate IO statistics");
+        }
+    } else {
+        // Key doesn't exist add it and allocate for them IO statistics
+        getStatisticsByKey(key);
+    }
 }
 
 void FilesystemStatistics::count(IFileSystemViewer *viewer,
@@ -115,17 +112,14 @@ void FilesystemStatistics::count(IFileSystemViewer *viewer,
         const auto &device = event.device();
 
         FileId id = FileId(event);
+        Key key(device.id());
 
-        auto &statistics = getStatisticsByIds(viewer, viewer->getParentId(id),
-                                              device.id());
-        statistics.updateIoStats(event);
+        getStatisticsByKey(key).updateIoStats(event);
 
         {
             // Update statistics by file extension
             auto ext = viewer->getFileExtension(id);
             if (ext != "") {
-                Key key(StatisticsCase::kFileExtension, ext, device.id(),
-                        device.partition());
                 getStatisticsByKey(key).updateIoStats(event);
             }
         }
@@ -133,158 +127,38 @@ void FilesystemStatistics::count(IFileSystemViewer *viewer,
             // Update statistics by base name
             auto basename = viewer->getFileNamePrefix(id);
             if (basename != "") {
-                Key key(StatisticsCase::kFileNamePrefix, basename, device.id(),
-                        device.partition());
                 getStatisticsByKey(key).updateIoStats(event);
             }
         }
     }
 }
 
-void FilesystemStatistics::getFilesystemStatistics(
-        proto::FilesystemStatistics *statistics) const {
-    fillProtoStatistics(statistics, "");
-}
-
-FilesystemStatistics &FilesystemStatistics::getStatisticsByIds(
-        IFileSystemViewer *viewer,
-        const FileId &dirId,
-        uint64_t devId) {
-    FilesystemStatistics *statistics = NULL;
-    FileId parentId = viewer->getParentId(dirId);
-
-    if (parentId == dirId) {
-        statistics = this;
-    } else {
-        statistics = &getStatisticsByIds(viewer, parentId, devId);
-    }
-
-    std::string name = viewer->getFileName(dirId);
-    Key key(StatisticsCase::kDirectory, name, devId, dirId.partitionId);
-
-    return statistics->getStatisticsByKey(key);
-}
-
-void FilesystemStatistics::fillProtoStatistics(
-        proto::FilesystemStatistics *statistics,
-        const std::string &dir) const {
-    proto::FilesystemStatisticsEntry entry;
-
-    if (dir != "") {
-        fillProtoStatisticsEntry(&entry, dir);
-
-        if (m_statsCase != StatisticsCase::kDirectory) {
-            auto &metrics = *entry.mutable_statistics()
-                                     ->mutable_write()
-                                     ->mutable_metrics();
-
-            if (metrics[WIF_METRIC_NAME].value() > 1.0L) {
-                // For non-directory stats, add only statistics which have write
-                // invalidation factor greater than 1.0. It minimize output
-                // size.
-                statistics->add_entries()->CopyFrom(entry);
-            }
-        } else {
-            statistics->add_entries()->CopyFrom(entry);
-        }
-    }
-
-    for (const auto &child : m_children) {
-        std::string name = child.first.name;
-        auto statsCase = child.first.statsCase;
-
-        if (name.empty()) {
-            continue;
-        }
-
-        if (statsCase == StatisticsCase::kDirectory) {
-            // Directory case
-            if (name.back() != '/' && !dir.empty() && dir.back() != '/') {
-                name = dir + "/" + name;
-            } else {
-                name = dir + name;
-            }
-        }
-
-        child.second.fillProtoStatistics(statistics, name);
-    }
-}
-
-void FilesystemStatistics::fillProtoStatisticsEntry(
-        proto::FilesystemStatisticsEntry *entry,
-        const std::string &name) const {
-    m_ioStats.getIoStatistics(entry->mutable_statistics());
-    entry->set_deviceid(m_devId);
-    entry->set_partitionid(m_partId);
-
-    // Clear proto statistics
-    auto pStats = entry->mutable_statistics();
-    pStats->clear_flush();
-    pStats->clear_discard();
-    pStats->mutable_read()->clear_latency();
-    pStats->mutable_write()->clear_latency();
-    pStats->mutable_total()->clear_latency();
-    pStats->mutable_read()->mutable_size()->clear_percentiles();
-    pStats->mutable_write()->mutable_size()->clear_percentiles();
-    pStats->mutable_total()->mutable_size()->clear_percentiles();
-
-    // Calculate WIF and insert metric
-    auto metrics = pStats->mutable_write()->mutable_metrics();
-    double workset = (*metrics)["workset"].value();
-    double written =
-            pStats->write().size().total() + pStats->discard().size().total();
-
-    double wif = 0.0L;
-    if (workset != 0.0L) {
-        wif = written / workset;
-    }
-
-    (*metrics)[WIF_METRIC_NAME].set_value(wif);
-
-    switch (m_statsCase) {
-    case StatisticsCase::kDirectory:
-        entry->set_directory(name);
-        break;
-    case StatisticsCase::kFileNamePrefix:
-        entry->set_filenameprefix(name);
-        break;
-    case StatisticsCase::kFileExtension:
-        entry->set_fileextension(name);
-        break;
-    default:
-        throw Exception("Invalid statistics case");
-        break;
-    }
-}
-
-void FilesystemStatistics::updateIoStats(
-        const proto::trace::ParsedEvent &event) {
-    m_ioStats.count(event);
-}
-
 void FilesystemStatistics::discard(const proto::trace::ParsedEvent &event) {
-    if (m_devId == event.device().id()) {
-        m_ioStats.count(event);
-    }
-
-    for (auto &child : m_children) {
+    for (auto &child : m_map) {
         child.second.discard(event);
     }
 }
 
-FilesystemStatistics &FilesystemStatistics::getStatisticsByKey(const Key &key) {
-    auto iter = m_children.find(key);
-    if (iter != m_children.end()) {
-        return iter->second;
+void FilesystemStatistics::getFilesystemStatistics(
+        proto::FilesystemStatistics *statistics) const {
+	FilesystemStatisticsEntry entry;
+	entry.fillProtoStatistics(statistics, "");
+}
+
+FilesystemStatisticsEntry &FilesystemStatistics::getStatisticsByKey(const Key &key) {
+    auto iter = m_map.find(key);
+    if (iter != m_map.end()) {
+        auto pair = std::make_pair(Key(key), FilesystemStatisticsEntry());
+
+        auto result = m_map.emplace(pair);
+        if (!result.second || result.first == m_map.end()) {
+            throw Exception("Cannot allocate FS statistics");
+        }
+
+        iter = result.first;
     }
 
-    auto &newFsStats = m_children[key];
-
-    newFsStats.m_devId = key.devId;
-    newFsStats.m_partId = key.partId;
-    newFsStats.m_statsCase = key.statsCase;
-
-    return newFsStats;
+    return iter->second;
 }
 
 } /* namespace octf */

--- a/source/octf/analytics/statistics/FilesystemStatistics.h
+++ b/source/octf/analytics/statistics/FilesystemStatistics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2012-2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -9,6 +9,7 @@
 #include <map>
 #include <string>
 #include <octf/analytics/statistics/IoStatistics.h>
+#include <octf/analytics/statistics/FilesystemStatisticsEntry.h>
 #include <octf/fs/IFileSystemViewer.h>
 #include <octf/proto/parsedTrace.pb.h>
 #include <octf/proto/statistics.pb.h>
@@ -38,6 +39,13 @@ public:
                const proto::trace::ParsedEvent &event);
 
     /**
+     * @brief Add devices to the FS statistics
+     *
+     * @param devDesc Device description trace event
+     */
+    void addDevice(const proto::trace::EventDeviceDescription &devDesc);
+
+    /**
      * Get Filesystem statistics in protocol buffer format
      *
      * @param[out] statistics Protocol buffer filesystem statistics
@@ -49,19 +57,7 @@ public:
 private:
     struct Key;
 
-    FilesystemStatistics &getStatisticsByKey(const Key &key);
-
-    FilesystemStatistics &getStatisticsByIds(IFileSystemViewer *viewer,
-                                             const FileId &dirId,
-                                             uint64_t devId);
-
-    void fillProtoStatistics(proto::FilesystemStatistics *statistics,
-                             const std::string &dir) const;
-
-    void fillProtoStatisticsEntry(proto::FilesystemStatisticsEntry *entry,
-                                  const std::string &name) const;
-
-    void updateIoStats(const proto::trace::ParsedEvent &event);
+    FilesystemStatisticsEntry &getStatisticsByKey(const Key &key);
 
     void discard(const proto::trace::ParsedEvent &event);
 
@@ -69,21 +65,7 @@ private:
     /**
      * Filesystem statistics for children directories
      */
-    std::map<Key, FilesystemStatistics> m_children;
-
-    /**
-     * IO statistics
-     */
-    IoStatistics m_ioStats;
-
-    uint64_t m_devId;
-    uint64_t m_partId;
-
-    using StatisticsCase = proto::FilesystemStatisticsEntry::NameCase;
-    /**
-     * Statistics Case
-     */
-    StatisticsCase m_statsCase;
+    std::map<Key, FilesystemStatisticsEntry> m_map;
 };
 
 }  // namespace octf

--- a/source/octf/analytics/statistics/FilesystemStatisticsEntry.cpp
+++ b/source/octf/analytics/statistics/FilesystemStatisticsEntry.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright(c) 2012-2020 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include <octf/analytics/statistics/FilesystemStatisticsEntry.h>
+
+namespace octf {
+
+struct FilesystemStatisticsEntry::EntryKey {
+    EntryKey()
+            : name()
+            , partId()
+            , statsCase(StatisticsCase::NAME_NOT_SET) {}
+
+    EntryKey(StatisticsCase sCase,
+        const std::string &name,
+        uint64_t partId)
+            : name(name)
+            , partId(partId)
+            , statsCase(sCase) {}
+
+    virtual ~EntryKey() {}
+
+    EntryKey(const EntryKey &other)
+            : name(other.name)
+            , partId(other.partId)
+            , statsCase(other.statsCase) {}
+
+    EntryKey &operator=(const EntryKey &other) {
+        if (this != &other) {
+            name = other.name;
+            partId = other.partId;
+            statsCase = other.statsCase;
+        }
+
+        return *this;
+    }
+
+    bool operator==(const EntryKey &other) const {
+        return name == other.name && partId == other.partId &&
+        		statsCase == other.statsCase;
+    }
+
+    bool operator!=(const EntryKey &other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const EntryKey &other) const {
+        int result = name.compare(other.name);
+        if (0 == result) {
+            if (partId != other.partId) {
+                return partId < other.partId;
+            } else {
+                return statsCase < other.statsCase;
+            }
+        }
+
+        return result < 0;
+    }
+
+    std::string name;
+    uint64_t partId;
+    StatisticsCase statsCase;
+};
+
+FilesystemStatisticsEntry::FilesystemStatisticsEntry()
+        : m_children()
+        , m_ioStats()
+        , m_partId()
+        , m_statsCase(StatisticsCase::NAME_NOT_SET) {}
+
+FilesystemStatisticsEntry::~FilesystemStatisticsEntry() {}
+
+FilesystemStatisticsEntry::FilesystemStatisticsEntry(const FilesystemStatisticsEntry &other)
+        : m_children(other.m_children)
+        , m_ioStats(other.m_ioStats)
+        , m_partId(other.m_partId)
+        , m_statsCase(other.m_statsCase) {}
+
+FilesystemStatisticsEntry &FilesystemStatisticsEntry::operator=(
+        const FilesystemStatisticsEntry &other) {
+    if (&other != this) {
+        m_children = other.m_children;
+        m_ioStats = other.m_ioStats;
+        m_partId = other.m_partId;
+        m_statsCase = other.m_statsCase;
+    }
+
+    return *this;
+}
+
+void FilesystemStatisticsEntry::fillProtoStatistics(
+        proto::FilesystemStatistics *statistics,
+        const std::string &dir) const {
+    proto::FilesystemStatisticsEntry entry;
+
+    if (dir != "") {
+        fillProtoStatisticsEntry(&entry, dir);
+
+        if (m_statsCase != StatisticsCase::kDirectory) {
+            auto &metrics = *entry.mutable_statistics()
+                                     ->mutable_write()
+                                     ->mutable_metrics();
+
+            if (metrics[WIF_METRIC_NAME].value() > 1.0L) {
+                // For non-directory stats, add only statistics which have write
+                // invalidation factor greater than 1.0. It minimize output
+                // size.
+                statistics->add_entries()->CopyFrom(entry);
+            }
+        } else {
+            statistics->add_entries()->CopyFrom(entry);
+        }
+    }
+
+    for (const auto &child : m_children) {
+        std::string name = child.first.name;
+        auto statsCase = child.first.statsCase;
+
+        if (name.empty()) {
+            continue;
+        }
+
+        if (statsCase == StatisticsCase::kDirectory) {
+            // Directory case
+            if (name.back() != '/' && !dir.empty() && dir.back() != '/') {
+                name = dir + "/" + name;
+            } else {
+                name = dir + name;
+            }
+        }
+
+        child.second.fillProtoStatistics(statistics, name);
+    }
+}
+
+void FilesystemStatisticsEntry::fillProtoStatisticsEntry(
+        proto::FilesystemStatisticsEntry *entry,
+        const std::string &name) const {
+    m_ioStats.getIoStatistics(entry->mutable_statistics());
+    entry->set_partitionid(m_partId);
+
+    // Clear proto statistics
+    auto pStats = entry->mutable_statistics();
+    pStats->clear_flush();
+    pStats->clear_discard();
+    pStats->mutable_read()->clear_latency();
+    pStats->mutable_write()->clear_latency();
+    pStats->mutable_total()->clear_latency();
+    pStats->mutable_read()->mutable_size()->clear_percentiles();
+    pStats->mutable_write()->mutable_size()->clear_percentiles();
+    pStats->mutable_total()->mutable_size()->clear_percentiles();
+
+    // Calculate WIF and insert metric
+    auto metrics = pStats->mutable_write()->mutable_metrics();
+    double workset = (*metrics)["workset"].value();
+    double written =
+            pStats->write().size().total() + pStats->discard().size().total();
+
+    double wif = 0.0L;
+    if (workset != 0.0L) {
+        wif = written / workset;
+    }
+
+    (*metrics)[WIF_METRIC_NAME].set_value(wif);
+
+    switch (m_statsCase) {
+    case StatisticsCase::kDirectory:
+        entry->set_directory(name);
+        break;
+    case StatisticsCase::kFileNamePrefix:
+        entry->set_filenameprefix(name);
+        break;
+    case StatisticsCase::kFileExtension:
+        entry->set_fileextension(name);
+        break;
+    default:
+        throw Exception("Invalid statistics case");
+        break;
+    }
+}
+
+void FilesystemStatisticsEntry::updateIoStats(
+        const proto::trace::ParsedEvent &event) {
+    m_ioStats.count(event);
+}
+
+void FilesystemStatisticsEntry::discard(const proto::trace::ParsedEvent &event) {
+    if (m_partId == event.device().partition()) {
+        m_ioStats.count(event);
+    }
+
+    for (auto &child : m_children) {
+        child.second.discard(event);
+    }
+}
+
+} /* namespace octf */

--- a/source/octf/analytics/statistics/FilesystemStatisticsEntry.h
+++ b/source/octf/analytics/statistics/FilesystemStatisticsEntry.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright(c) 2012-2020 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef SOURCE_OCTF_ANALYTICS_STATISTICS_FILESYSTEMSTATISTICS_ENTRY_H
+#define SOURCE_OCTF_ANALYTICS_STATISTICS_FILESYSTEMSTATISTICS_ENTRY_H
+
+#include <map>
+#include <string>
+#include <octf/analytics/statistics/IoStatistics.h>
+#include <octf/fs/IFileSystemViewer.h>
+#include <octf/proto/parsedTrace.pb.h>
+#include <octf/proto/statistics.pb.h>
+
+namespace octf {
+
+/**
+ * @ingroup Statistics
+ *
+ * @brief Filesystem statistics breakdown by directories, file extensions, etc.
+ *
+ */
+class FilesystemStatisticsEntry {
+public:
+    FilesystemStatisticsEntry();
+    virtual ~FilesystemStatisticsEntry();
+    FilesystemStatisticsEntry(FilesystemStatisticsEntry const &other);
+    FilesystemStatisticsEntry &operator=(FilesystemStatisticsEntry const &other);
+
+    static constexpr auto WIF_METRIC_NAME = "write invalidation factor";
+
+    void updateIoStats(const proto::trace::ParsedEvent &event);
+
+    struct EntryKey;
+
+    void fillProtoStatistics(proto::FilesystemStatistics *statistics,
+                             const std::string &dir) const;
+
+    void fillProtoStatisticsEntry(proto::FilesystemStatisticsEntry *entry,
+                                  const std::string &name) const;
+
+    void discard(const proto::trace::ParsedEvent &event);
+
+private:
+    /**
+     * Filesystem statistics for children directories
+     */
+    std::map<EntryKey, FilesystemStatisticsEntry> m_children;
+
+    /**
+     * IO statistics
+     */
+    IoStatistics m_ioStats;
+
+    uint64_t m_partId;
+
+    using StatisticsCase = proto::FilesystemStatisticsEntry::NameCase;
+    /**
+     * Statistics Case
+     */
+    StatisticsCase m_statsCase;
+};
+
+}  // namespace octf
+
+#endif  // SOURCE_OCTF_ANALYTICS_STATISTICS_FILESYSTEMSTATISTICS_ENTRY_H

--- a/source/octf/proto/statistics.proto
+++ b/source/octf/proto/statistics.proto
@@ -233,7 +233,7 @@ message IoHistogramSet {
  * Filesystem statistics
  */
 message FilesystemStatisticsEntry {
-    uint64 deviceId = 1;
+    IoStatisticsDescription desc = 1;
 
     uint64 partitionId = 2;
 

--- a/source/octf/trace/parser/TraceEventHandlerFilesystemStatistics.cpp
+++ b/source/octf/trace/parser/TraceEventHandlerFilesystemStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2012-2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -24,6 +24,11 @@ void TraceEventHandlerFilesystemStatistics::handleIO(
 void TraceEventHandlerFilesystemStatistics::getFilesystemStatistics(
         proto::FilesystemStatistics *fsStats) const {
     m_fsStats.getFilesystemStatistics(fsStats);
+}
+
+void TraceEventHandlerFilesystemStatistics::handleDeviceDescription(
+        const proto::trace::EventDeviceDescription &devDesc) {
+	m_fsStats.addDevice(devDesc);
 }
 
 }  // namespace octf

--- a/source/octf/trace/parser/TraceEventHandlerFilesystemStatistics.h
+++ b/source/octf/trace/parser/TraceEventHandlerFilesystemStatistics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2012-2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -7,6 +7,7 @@
 #define SOURCE_OCTF_TRACE_PARSER_TRACEEVENTHANDLERFILESYSTEMSTATISTICS_H
 
 #include <octf/analytics/statistics/FilesystemStatistics.h>
+#include <octf/analytics/statistics/FilesystemStatisticsEntry.h>
 #include <octf/proto/statistics.pb.h>
 #include <octf/trace/parser/ParsedIoTraceEventHandler.h>
 
@@ -30,6 +31,10 @@ public:
      * @param[out] fsStats Filesystem statistics in protocol buffer format
      */
     void getFilesystemStatistics(proto::FilesystemStatistics *fsStats) const;
+
+protected:
+    void handleDeviceDescription(
+            const proto::trace::EventDeviceDescription &devDesc) override;
 
 private:
     FilesystemStatistics m_fsStats;


### PR DESCRIPTION
Change showing device's id to grouping statistics by device's description.
Fixes https://github.com/Open-CAS/standalone-linux-io-tracer/issues/166

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>