### PR TITLE
Call Message::ByteSizeLong() instead of Message::ByteSize()

### DIFF
--- a/source/octf/interface/internal/FileTraceSerializer.cpp
+++ b/source/octf/interface/internal/FileTraceSerializer.cpp
@@ -94,7 +94,7 @@ bool FileTraceSerializer::serialize(
         return false;
     }
 
-    int messageLength = message->ByteSize();
+    auto messageLength = message->ByteSizeLong();
 
     uint8_t *buffer = getBuffer(protoconverter::MAX_VARINT32_BYTES);
     if (!buffer) {


### PR DESCRIPTION
Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>