### PR TITLE
Suppress error messages in ProtobufReaderWriter

### DIFF
--- a/source/octf/utils/ProtobufReaderWriter.cpp
+++ b/source/octf/utils/ProtobufReaderWriter.cpp
@@ -24,7 +24,8 @@ ProtobufReaderWriter::ProtobufReaderWriter(const std::string &filePath)
         : m_filePath(filePath)
         , m_directoryPath("")
         , m_readFd(-1)
-        , m_writeFd(-1) {
+        , m_writeFd(-1)
+        , m_verbose(false) {
     std::size_t dirEndPos = filePath.rfind('/');
 
     if (dirEndPos == 0) {
@@ -44,8 +45,11 @@ bool ProtobufReaderWriter::read(google::protobuf::Message &message) {
     openFileToRead();
 
     if (m_readFd == -1) {
-        log::cerr << "Could not open file " << m_filePath
-                  << " for reading: " << std::string(strerror(errno));
+        if (m_verbose) {
+            log::cerr << "Could not open file " << m_filePath
+                      << " for reading: " << std::string(strerror(errno))
+                      << std::endl;
+        }
         return false;
     }
 
@@ -86,8 +90,11 @@ bool ProtobufReaderWriter::write(const google::protobuf::Message &message) {
     openFileToWrite();
 
     if (m_writeFd == -1) {
-        log::cerr << "Could not open file " << m_filePath
-                  << " for writing: " << std::string(strerror(errno));
+        if (m_verbose) {
+            log::cerr << "Could not open file " << m_filePath
+                      << " for writing: " << std::string(strerror(errno))
+                      << std::endl;
+        }
         return false;
     }
 

--- a/source/octf/utils/ProtobufReaderWriter.h
+++ b/source/octf/utils/ProtobufReaderWriter.h
@@ -77,6 +77,25 @@ public:
      */
     bool makeReadOnly();
 
+    /**
+     * @brief Checks if printing errors is enabled
+     * @retval true Errors messages will be printed
+     * @retval false Errors message will be suppressed
+     */
+    bool isVerbose() const {
+        return m_verbose;
+    }
+
+    /**
+     * @brief Enables printing error message
+     *
+     * @param verbose Flags controlling printing error messages. If verbose true
+     * then error messages will be printed. Otherwise not.
+     */
+    void setVerbose(bool verbose) {
+        m_verbose = verbose;
+    }
+
 private:
     /**
      * @brief This opens the file and gets a file descriptor for reading.
@@ -119,6 +138,11 @@ private:
      * File descriptor for writing
      */
     int m_writeFd;
+
+    /**
+     * Flags to control if print error
+     */
+    bool m_verbose;
 };
 
 }  // namespace octf


### PR DESCRIPTION
By default error messages from ProtobufReaderWriter are disabled.
They can be turn on by calling ProtobufReaderWriter::setVerbose(true)

Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>