### PR TITLE
Add V1 version of traces

### DIFF
--- a/source/octf/interface/TraceConverter.cpp
+++ b/source/octf/interface/TraceConverter.cpp
@@ -11,7 +11,7 @@
 
 namespace octf {
 
-constexpr int32_t TRACE_VERSION = 0;
+constexpr int32_t TRACE_VERSION = 1;
 
 TraceConverter::TraceConverter()
         : m_evDesc(std::make_shared<proto::trace::Event>())
@@ -90,6 +90,7 @@ std::shared_ptr<const google::protobuf::Message> TraceConverter::convertTrace(
         protoIo->set_ioclass(event->io_class);
         protoIo->set_deviceid(event->dev_id);
         protoIo->set_writehint(event->write_hint);
+        protoIo->set_id(event->id);
 
         return m_evIO;
     }
@@ -112,6 +113,7 @@ std::shared_ptr<const google::protobuf::Message> TraceConverter::convertTrace(
         protoIoCmpl->set_len(event->len);
         protoIoCmpl->set_error(event->error);
         protoIoCmpl->set_deviceid(event->dev_id);
+        protoIoCmpl->set_refid(event->ref_id);
 
         return m_evIOCmpl;
     }

--- a/source/octf/proto/trace.proto
+++ b/source/octf/proto/trace.proto
@@ -133,6 +133,7 @@ message EventIoCompletion {
 message EventIoFilesystemMeta {
     /**
      * Event sequence ID reference to IO trace event associated with this event
+     * TODO: For v1 of parser this is just reference IO trace event ID
      */
     uint64 refSid = 1;
 

--- a/source/octf/proto/trace.proto
+++ b/source/octf/proto/trace.proto
@@ -91,6 +91,12 @@ message EventIo {
 
     /** Write (lifetime) hint */
     uint32 writeHint = 8;
+
+    /**
+     * This ID can be used by the tracing environment to assign an ID to the IO.
+     * Zero means not set.
+     */
+    uint64 id = 9;
 }
 
 /**
@@ -108,6 +114,12 @@ message EventIoCompletion {
 
     /** Device ID */
     uint64 deviceId = 4;
+
+    /**
+     * The ID of an IO which is completed. Environment can set ID of IO which is
+     * completed.
+     */
+    uint64 refId = 5;
 }
 
 /**

--- a/source/octf/trace/iotrace_event.h
+++ b/source/octf/trace/iotrace_event.h
@@ -18,7 +18,7 @@ extern "C" {
 
 typedef uint64_t log_sid_t;
 
-#define IOTRACE_EVENT_VERSION_MAJOR 4
+#define IOTRACE_EVENT_VERSION_MAJOR 5
 #define IOTRACE_EVENT_VERSION_MINOR 0
 
 #define IOTRACE_MAGIC 0x5a8e454ace7a51c1ULL
@@ -118,6 +118,14 @@ typedef enum {
 struct iotrace_event {
     /** Trace event header */
     struct iotrace_event_hdr hdr;
+    /**
+     * @brief IO ID
+     *
+     * This ID can be used by the tracing environment to assign an ID to the IO.
+     *
+     * @note Zero means not set.
+     */
+    uint64_t id;
 
     /** Address of IO in sectors */
     uint64_t lba;
@@ -131,14 +139,14 @@ struct iotrace_event {
     /** Device ID */
     uint32_t dev_id;
 
-    /** Operation type: read, write, discard
-     * (iotrace_event_operation_t enumerator) **/
-    uint32_t operation;
-
     /** Operation flags: flush, fua, ... .
      * Values according to iotrace_event_flag_t enum
      * are summed (OR-ed) together. */
     uint32_t flags;
+
+    /** Operation type: read, write, discard
+     * (iotrace_event_operation_t enumerator) **/
+    uint8_t operation;
 
     /** Write hint associated with IO */
     uint8_t write_hint;
@@ -150,6 +158,13 @@ struct iotrace_event {
 struct iotrace_event_completion {
     /** Trace event header */
     struct iotrace_event_hdr hdr;
+
+    /**
+     * @brief The ID of an IO which is completed
+     *
+     * Environment can set ID of IO which is completed
+     */
+    uint64_t ref_id;
 
     /** Address of completed IO in sectors */
     uint64_t lba;

--- a/source/octf/trace/parser/CMakeLists.txt
+++ b/source/octf/trace/parser/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(v0)
+add_subdirectory(v1)
 
 target_sources(octf
 PRIVATE

--- a/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/ParsedIoTraceEventHandler.cpp
@@ -7,6 +7,7 @@
 #include <octf/trace/TraceLibrary.h>
 #include <octf/trace/parser/ParsedIoTraceEventHandler.h>
 #include <octf/trace/parser/v0/ParsedIoTraceEventHandler.h>
+#include <octf/trace/parser/v1/ParsedIoTraceEventHandler.h>
 
 #include <octf/utils/Exception.h>
 
@@ -21,6 +22,10 @@ ParsedIoTraceEventHandler::ParsedIoTraceEventHandler(
     case 0:
         m_childParser = std::unique_ptr<trace::v0::ParsedIoTraceEventHandler>(
                 new trace::v0::ParsedIoTraceEventHandler(this, tracePath));
+        break;
+    case 1:
+        m_childParser = std::unique_ptr<trace::v1::ParsedIoTraceEventHandler>(
+                new trace::v1::ParsedIoTraceEventHandler(this, tracePath));
         break;
     default:
         throw Exception("Trying to parse unrecognized trace version");

--- a/source/octf/trace/parser/v1/CMakeLists.txt
+++ b/source/octf/trace/parser/v1/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(octf
+PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/ParsedIoTraceEventHandler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ParsedIoTraceEventHandler.h
+)

--- a/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.cpp
@@ -1,0 +1,608 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include <octf/trace/parser/v1/ParsedIoTraceEventHandler.h>
+
+#include <limits.h>
+#include <chrono>
+#include <list>
+#include <map>
+#include <octf/fs/FileId.h>
+#include <octf/utils/Exception.h>
+#include <octf/utils/Log.h>
+#include <octf/utils/NonCopyable.h>
+
+namespace octf {
+namespace trace {
+namespace v1 {
+
+struct ParsedIoTraceEventHandler::IoQueueDepth {
+    uint64_t Value;
+    uint64_t Adjustment;
+};
+
+/**
+ * Tiny structure of file info containing parent file id, last size of file,
+ * name, etc.
+ *
+ * To reduced memory overhead, we introduced own version of file info,
+ * instead of using protocol buffer one
+ */
+struct ParsedIoTraceEventHandler::FileInfo {
+    FileId parent;
+    std::string name;
+    uint64_t size;
+
+    FileInfo()
+            : parent()
+            , name()
+            , size(0) {}
+
+    FileInfo(const proto::trace::EventIoFilesystemFileName &event)
+            : parent(event)
+            , name(event.filename())
+            , size(0) {}
+
+    FileInfo(const FileInfo &other)
+            : parent(other.parent)
+            , name(other.name)
+            , size(other.size) {}
+
+    FileInfo &operator=(const FileInfo &other) {
+        if (this != &other) {
+            parent = other.parent;
+            name = other.name;
+            size = other.size;
+        }
+
+        return *this;
+    }
+};
+
+constexpr uint64_t ParsedIoTraceEventHandler_QueueLimit = 10000;
+
+ParsedIoTraceEventHandler::ParsedIoTraceEventHandler(
+        octf::ParsedIoTraceEventHandler *parentHandler,
+        const std::string &tracePath)
+        : IoTraceParser(tracePath)
+        , m_queue()
+        , m_refSid(0)
+        , m_idMapping()
+        , m_devices()
+        , m_fileInfo()
+        , m_timestampOffset(0)
+        , m_limit(ParsedIoTraceEventHandler_QueueLimit)
+        , m_subrangeStart(0)
+        , m_subrangeEnd(0)
+        , m_devIoQueueDepth()
+        , m_parentHandler(parentHandler) {}
+
+ParsedIoTraceEventHandler::~ParsedIoTraceEventHandler() {}
+
+void ParsedIoTraceEventHandler::processEvents() {
+    TraceEventHandler<proto::trace::Event>::processEvents();
+    flushEvents();
+}
+
+void ParsedIoTraceEventHandler::handleEvent(
+        std::shared_ptr<proto::trace::Event> traceEvent) {
+    using namespace proto::trace;
+    using octf::FileId;
+
+    if (!m_timestampOffset) {
+        // This event handler presents traces from time '0', and SID '0',
+        // we remember the first event time stamp and SID and the subtract
+        // by those values for each event
+        m_timestampOffset = traceEvent->header().timestamp();
+    }
+
+    switch (traceEvent->EventType_case()) {
+    case Event::EventTypeCase::kDeviceDescription: {
+        // Remember device
+        const auto &device = traceEvent->devicedescription();
+        m_devices[device.id()] = device;
+        m_limit = ParsedIoTraceEventHandler_QueueLimit * m_devices.size();
+        m_parentHandler->handleDeviceDescription(device);
+    } break;
+
+    case Event::EventTypeCase::kIo: {
+        const auto &io = traceEvent->io();
+        auto deviceId = io.deviceid();
+
+        // If subrange is set, skip IO events which are outside of it
+        if (m_subrangeEnd != 0) {
+            if (io.lba() + io.len() < m_subrangeStart ||
+                io.lba() > m_subrangeEnd) {
+                return;
+            }
+        }
+
+        // Allocate new parsed IO event in the queue
+        m_queue.emplace(ParsedEvent());
+        auto &cachedEvent = m_queue.back();
+
+        // Setup parsed IO
+        cachedEvent.mutable_header()->CopyFrom(traceEvent->header());
+
+        auto &dst = *cachedEvent.mutable_io();
+        const auto &src = traceEvent->io();
+
+        dst.set_lba(src.lba());
+        dst.set_len(src.len());
+        dst.set_ioclass(src.ioclass());
+        dst.set_operation(src.operation());
+        dst.set_flush(src.flush());
+        dst.set_fua(src.fua());
+        dst.set_writehint(src.writehint());
+
+        auto &qd = m_devIoQueueDepth[deviceId];
+        qd.Value++;
+        dst.set_qd(qd.Value);
+
+        auto *devInfo = cachedEvent.mutable_device();
+        devInfo->set_name(m_devices[deviceId].name());
+        devInfo->set_id(deviceId);
+        devInfo->set_partition(deviceId);
+
+        addMapping(*traceEvent, cachedEvent);
+    } break;
+
+    case Event::EventTypeCase::kIoCompletion: {
+        auto devId = traceEvent->iocompletion().deviceid();
+        auto &hdr = traceEvent->header();
+        auto &cmpl = traceEvent->iocompletion();
+
+        // If subrange is set, skip events which are outside of it
+        if (m_subrangeEnd != 0) {
+            if (cmpl.lba() + cmpl.len() < m_subrangeStart ||
+                cmpl.lba() > m_subrangeEnd) {
+                return;
+            }
+        }
+
+        // Get queue depth
+        auto &qd = m_devIoQueueDepth[devId];
+
+        // Find in map which IO has been completed.
+        auto id = cmpl.refid();
+        auto event = getCachedEventById(id);
+        if (nullptr != event) {
+            delMapping(*event);
+
+            auto io = event->mutable_io();
+            uint64_t submissionTime = event->header().timestamp();
+            uint64_t completionTime = hdr.timestamp();
+
+            if (completionTime < submissionTime) {
+                // Submission after completion - IO probably dropped
+                if (qd.Adjustment) {
+                    qd.Adjustment--;
+                }
+            } else {
+                auto latency = completionTime - submissionTime;
+
+                // IO found, set latency and result of IO
+                io->set_latency(latency);
+                io->set_error(cmpl.error());
+                io->set_lba(cmpl.lba());
+                io->set_len(cmpl.len());
+
+                // Update queue depth for device
+                if (qd.Value) {
+                    qd.Value--;
+
+                    if (qd.Value < qd.Adjustment) {
+                        // taking into account adjustment, we reached zero queue
+                        // depth, so reset both counters
+                        qd.Value = 0;
+                        qd.Adjustment = 0;
+                    }
+                }
+            }
+        } else {
+            // IO not found, probably event dropped during tracing
+            if (qd.Adjustment) {
+                qd.Adjustment--;
+            }
+        }
+
+        flushEvents();
+    } break;
+
+    case Event::kFilesystemMeta: {
+        auto id = traceEvent->filesystemmeta().refsid();
+        auto cachedEvent = getCachedEventById(id);
+
+        if (cachedEvent) {
+            auto &dst = *cachedEvent->mutable_file();
+            const auto &src = traceEvent->filesystemmeta();
+            dst.set_id(src.fileid().id());
+            dst.set_offset(src.fileoffset());
+            dst.set_size(src.filesize());
+
+            // Update filesystem event type to just file access
+            dst.set_eventtype(proto::trace::FsEventType::Access);
+
+            // Fill creation event
+            dst.mutable_creationdate()->CopyFrom(src.fileid().creationdate());
+
+            // Set partition ID
+            auto partId = traceEvent->filesystemmeta().fileid().partitionid();
+            auto devInfo = cachedEvent->mutable_device();
+            devInfo->set_partition(partId);
+
+            // Add device description for given partition
+            auto devIter = m_devices.find(partId);
+            if (devIter == m_devices.end()) {
+                m_devices[partId].CopyFrom(m_devices[devInfo->id()]);
+            }
+
+            // Update size in file info
+            auto size = src.filesize();
+            m_fileInfo[FileId(src)].size = size;
+        }
+    } break;
+
+    case Event::EventTypeCase::kFilesystemFileEvent: {
+        const auto &fsEvent = traceEvent->filesystemfileevent();
+        auto partId = fsEvent.fileid().partitionid();
+        FileId file = FileId(fsEvent);
+
+        // Allocate new parsed IO event in the queue
+        m_queue.emplace(ParsedEvent());
+        auto &cachedEvent = m_queue.back();
+
+        // Setup parsed IO
+        cachedEvent.mutable_header()->CopyFrom(traceEvent->header());
+
+        // Setup file event type and parent id
+        auto &dstFileInfo = *cachedEvent.mutable_file();
+        dstFileInfo.set_eventtype(fsEvent.fseventtype());
+        dstFileInfo.set_id(fsEvent.fileid().id());
+        dstFileInfo.mutable_creationdate()->CopyFrom(
+                fsEvent.fileid().creationdate());
+
+        auto &destDevInfo = *cachedEvent.mutable_device();
+        const auto &srcDevInfo = m_devices[partId];
+        destDevInfo.set_name(srcDevInfo.name());
+        destDevInfo.set_id(srcDevInfo.id());
+        destDevInfo.set_partition(partId);
+
+        // Set file size from file info
+        auto size = m_fileInfo[file].size;
+        dstFileInfo.set_size(size);
+        if (fsEvent.fseventtype() == FsEventType::Delete) {
+            m_fileInfo.erase(file);
+        }
+    } break;
+
+    case Event::EventTypeCase::kFilesystemFileName: {
+        const auto &fsNameEvent = traceEvent->filesystemfilename();
+        FileId fileId(fsNameEvent);
+        auto &fileInfo = m_fileInfo[fileId];
+
+        fileInfo.name = fsNameEvent.filename();
+        fileInfo.parent = FileId(fsNameEvent.fileparentid());
+    } break;
+
+    default:
+        break;
+    }
+}
+
+void ParsedIoTraceEventHandler::flushEvents() {
+    while (m_queue.size()) {
+        if (m_queue.front().io().latency()) {
+            pushOutEvent();
+        } else {
+            break;
+        }
+    }
+
+    bool isFinished = getParser()->isFinished();
+
+    if (m_queue.size() < m_limit && !isFinished) {
+        return;
+    }
+
+    // Cache exceeds some number,
+    // or every parser finished its job, then flush IOs
+    while (m_queue.size()) {
+        pushOutEvent();
+
+        if (!isFinished && m_queue.size() < m_limit) {
+            break;
+        }
+    }
+}
+
+void ParsedIoTraceEventHandler::pushOutEvent() {
+    auto &event = m_queue.front();
+
+    delMapping(event);
+
+    // Update SID
+    event.mutable_header()->set_sid(++m_refSid);
+
+    // Take into account IO queue depth adjustment
+    auto devId = event.device().id();
+    auto partId = event.device().partition();
+    auto &qd = m_devIoQueueDepth[devId];
+
+    if (event.has_io()) {
+        auto ioqd = event.io().qd();
+        if (qd.Adjustment < ioqd) {
+            ioqd -= qd.Adjustment;
+        } else {
+            ioqd = 1;
+        }
+        event.mutable_io()->set_qd(ioqd);
+    }
+
+    // Update timestamp
+    auto timestamp = event.header().timestamp();
+    if (timestamp > m_timestampOffset) {
+        event.mutable_header()->set_timestamp(timestamp -= m_timestampOffset);
+    } else {
+        event.mutable_header()->set_timestamp(0);
+    }
+
+    if (event.has_file()) {
+        auto viewer = getFileSystemViewer(partId);
+        event.mutable_file()->set_path(viewer->getFilePath(FileId(event)));
+    }
+
+    // Call handler
+    m_parentHandler->handleIO(event);
+
+    if (event.has_io() && 0 == event.io().latency()) {
+        // An IO completion lost, so the queue depth of next IOs are disrupted,
+        // Set queue depth adjustment
+        qd.Adjustment++;
+    }
+
+    m_queue.pop();
+}
+
+void ParsedIoTraceEventHandler::addMapping(
+        const proto::trace::Event &traceEvent,
+        proto::trace::ParsedEvent &cachedEvent) {
+    if (!traceEvent.has_io()) {
+        return;
+    }
+    auto id = traceEvent.io().id();
+
+    if (id) {
+        auto pair = std::make_pair(id, &cachedEvent);
+        auto result = m_idMapping.emplace(pair);
+        if (!result.second) {
+            // Probably we dropped completion and we had not deleted previous
+            // mapping, replace previous ID mapping with new one
+            if (result.first != m_idMapping.end()) {
+                result.first->second = &cachedEvent;
+            } else {
+                throw Exception(
+                        "Error during trace parsing, cannot add ID mapping");
+            }
+        }
+
+        // Temporary store id in SID place
+        cachedEvent.mutable_header()->set_sid(id);
+    }
+}
+
+void ParsedIoTraceEventHandler::delMapping(
+        proto::trace::ParsedEvent &cachedEvent) {
+    if (cachedEvent.has_io()) {
+        auto id = cachedEvent.header().sid();
+        m_idMapping.erase(id);
+        cachedEvent.mutable_header()->set_sid(0);
+    }
+}
+
+proto::trace::ParsedEvent *ParsedIoTraceEventHandler::getCachedEventById(
+        uint64_t id) {
+    auto iter = m_idMapping.find(id);
+
+    if (iter != m_idMapping.end()) {
+        return iter->second;
+    } else {
+        return nullptr;
+    }
+}
+
+uint64_t ParsedIoTraceEventHandler::getDevicesSize() const {
+    uint64_t size = 0;
+
+    for (const auto &dev : m_devices) {
+        // In device map we code partition sizes as well, so peek only entire
+        // drives, takes place when key of map equals to id in map value.
+        if (dev.first == dev.second.id()) {
+            size += dev.second.size();
+        }
+    }
+
+    return size;
+}
+
+void ParsedIoTraceEventHandler::setExclusiveSubrange(uint64_t start,
+                                                     uint64_t end) {
+    m_subrangeStart = start;
+    m_subrangeEnd = end;
+}
+
+class ParsedIoTraceEventHandler::FileSystemViewer : public IFileSystemViewer {
+public:
+    FileSystemViewer(uint64_t partId,
+                     const std::map<FileId, FileInfo> &fileInfo)
+            : IFileSystemViewer()
+            , m_partId(partId)
+            , m_fileInfo(fileInfo) {}
+
+    virtual std::string getFileNamePrefix(const FileId &id) const override {
+        std::string basename = "";
+
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            auto i = iter->second.name.rfind('.');
+            if (i != std::string::npos) {
+                basename = iter->second.name.substr(0, i);
+            } else {
+                basename = iter->second.name;
+            }
+        }
+
+        while (basename.size()) {
+            if (std::isalpha(basename.back())) {
+                break;
+            } else {
+                basename.pop_back();
+            }
+        }
+
+        return basename;
+    }
+
+    virtual std::string getFileName(const FileId &id) const override {
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            return iter->second.name;
+        }
+
+        return "";
+    }
+
+    virtual std::string getFileExtension(const FileId &id) const override {
+        std::string extension = "";
+
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            auto i = iter->second.name.rfind('.');
+            if (i != std::string::npos) {
+                extension = iter->second.name.substr(i + 1);
+            }
+        }
+
+        return extension;
+    }
+
+    virtual std::string getDirPath(const FileId &id) const override {
+        std::string dir = "";
+        uint64_t len = 0;
+
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            try {
+                getPath(iter->second.parent, dir, len);
+            } catch (MaxPathExceededException &e) {
+                log::cerr << e.getMessage() << std::endl;
+            }
+        }
+
+        return dir;
+    }
+
+    virtual std::string getFilePath(const FileId &id) const override {
+        std::string path = "";
+
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            path = getDirPath(id);
+
+            if ("" == path) {
+                return "";
+            }
+
+            if (path != "/") {
+                path += "/";
+            }
+
+            path += iter->second.name;
+        }
+
+        return path;
+    }
+
+    virtual FileId getParentId(const FileId &id) const override {
+        FileId parentId = FileId();
+
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            const auto &info = iter->second;
+            return info.parent;
+        }
+
+        return parentId;
+    }
+
+private:
+    bool getPath(const FileId &id, std::string &path, uint64_t &len) const {
+        auto iter = m_fileInfo.find(id);
+        if (iter != m_fileInfo.end()) {
+            const auto &info = iter->second;
+            len += info.name.length();
+            if (len > PATH_MAX) {
+                throw MaxPathExceededException(id.id);
+            }
+            if (id != info.parent) {
+                if (!getPath(info.parent, path, len)) {
+                    path = "";
+                    return false;
+                }
+
+                if (!path.empty() && '/' != path.back()) {
+                    path += "/";
+                }
+            }
+
+            path += info.name;
+
+            return true;
+        } else {
+            path = "";
+            return false;
+        }
+    }
+
+private:
+    const uint64_t m_partId;
+    const std::map<FileId, FileInfo> &m_fileInfo;
+};
+
+IFileSystemViewer *ParsedIoTraceEventHandler::getFileSystemViewer(
+        uint64_t partitionId) {
+    IFileSystemViewer *viewer = NULL;
+
+    // Check if device with specified ID exist
+    if (m_devices.end() == m_devices.find(partitionId)) {
+        throw Exception("Requesting FS viewer for non-existing partition ID");
+    }
+
+    auto iter = m_partitionFsViewers.find(partitionId);
+    if (iter == m_partitionFsViewers.end()) {
+        // FS viewer has not be allocated yet.
+
+        // Create FS Viewer
+        auto pair = std::make_pair(partitionId,
+                                   FileSystemViewer(partitionId, m_fileInfo));
+
+        // Insert pair into map
+        auto result = m_partitionFsViewers.emplace(pair);
+
+        if (!result.second || result.first == m_partitionFsViewers.end()) {
+            throw Exception(
+                    "Error during trace parsing, cannot create FS viewer");
+        }
+
+        viewer = &result.first->second;
+    } else {
+        viewer = &iter->second;
+    }
+
+    return viewer;
+}
+}  // namespace v1
+}  // namespace trace
+}  // namespace octf

--- a/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.h
+++ b/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) 2012-2020 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef SOURCE_OCTF_TRACE_PARSER_V1_PARSEDIOTRACEEVENTHANDLER_H
+#define SOURCE_OCTF_TRACE_PARSER_V1_PARSEDIOTRACEEVENTHANDLER_H
+
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <octf/fs/FileId.h>
+#include <octf/fs/IFileSystemViewer.h>
+#include <octf/interface/internal/IoTraceParser.h>
+#include <octf/proto/parsedTrace.pb.h>
+#include <octf/proto/trace.pb.h>
+#include <octf/trace/parser/ParsedIoTraceEventHandler.h>
+#include <octf/trace/parser/TraceEventHandler.h>
+
+namespace octf {
+namespace trace {
+namespace v1 {
+/**
+ * This is IO trace event handler of parsed IO
+ *
+ * The parsed IO is created from multiple events (especially IO request and IO
+ * completion). It contains basic IO information (LBA, length, etc). It is
+ * supplemented by related information like filesystem one. In addition it
+ * provides post parse information (latency, queue depth, etc...).
+ *
+ * @note The order of handled IO respect the IOs queuing order
+ */
+class ParsedIoTraceEventHandler : public IoTraceParser {
+public:
+    ParsedIoTraceEventHandler(octf::ParsedIoTraceEventHandler *parentHandler,
+                              const std::string &tracePath);
+    virtual ~ParsedIoTraceEventHandler();
+
+    /**
+     * @return Sum of all devices sizes in sectors
+     */
+    uint64_t getDevicesSize() const;
+
+    void processEvents() override;
+
+protected:
+    /**
+     * Gets filesystem viewer interface
+     *
+     * This interface is used to inspect and view filesystem on the basis
+     * of captured IO traces.
+     *
+     * @param deviceID
+     *
+     * @return
+     */
+    IFileSystemViewer *getFileSystemViewer(uint64_t partitionID);
+
+    /**
+     * @brief Skip IO's outside of this defined subrange
+     * @param start LBA of subrange start
+     * @param end LBA of subrange end
+     *
+     * @note any IO's which overlap with this range will also be included
+     * @note when subrange is set, queue depth may be meaningless - use this
+     *  only when queue depth is not considered - also that's why it's protected
+     */
+    void setExclusiveSubrange(uint64_t start, uint64_t end);
+
+private:
+    bool compareEvents(const proto::trace::Event *a,
+                       const proto::trace::Event *b) override {
+        return a->header().sid() < b->header().sid();
+    }
+
+    void handleEvent(std::shared_ptr<proto::trace::Event> traceEvent) override;
+
+    void pushOutEvent();
+
+    void addMapping(const proto::trace::Event &traceEvent,
+                    proto::trace::ParsedEvent &cachedEvent);
+
+    void delMapping(proto::trace::ParsedEvent &cachedEvent);
+
+    proto::trace::ParsedEvent *getCachedEventById(uint64_t id);
+
+    void flushEvents();
+
+private:
+    struct IoQueueDepth;
+    class FileSystemViewer;
+    struct FileInfo;
+    std::queue<proto::trace::ParsedEvent> m_queue;
+    uint64_t m_refSid;
+    std::map<uint64_t, proto::trace::ParsedEvent *> m_idMapping;
+    std::map<uint64_t, proto::trace::EventDeviceDescription> m_devices;
+    std::map<FileId, FileInfo> m_fileInfo;
+    uint64_t m_timestampOffset;
+    uint64_t m_limit;
+    uint64_t m_subrangeStart;
+    uint64_t m_subrangeEnd;
+    std::map<uint64_t, IoQueueDepth> m_devIoQueueDepth;
+    std::map<uint64_t, FileSystemViewer> m_partitionFsViewers;
+    octf::ParsedIoTraceEventHandler *m_parentHandler;
+};
+
+}  // namespace v1
+}  // namespace trace
+}  // namespace octf
+
+#endif  // SOURCE_OCTF_TRACE_PARSER_V1_PARSEDIOTRACEEVENTHANDLER_H


### PR DESCRIPTION
Changes tracking of IO event completions, utilizing id references
instead of lba/len/device information.

Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>