### PR TITLE
Fix discard completion handling for v1 traces in <4.10 kernels

### DIFF
--- a/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.cpp
+++ b/source/octf/trace/parser/v1/ParsedIoTraceEventHandler.cpp
@@ -187,8 +187,13 @@ void ParsedIoTraceEventHandler::handleEvent(
                 // IO found, set latency and result of IO
                 io->set_latency(latency);
                 io->set_error(cmpl.error());
-                io->set_lba(cmpl.lba());
-                io->set_len(cmpl.len());
+
+                // Only update these fields if valid - fixes behavior for
+                // discards in kernels < 4.10
+                if (cmpl.lba() != 0 && cmpl.len() != 0) {
+                    io->set_lba(cmpl.lba());
+                    io->set_len(cmpl.len());
+                }
 
                 // Update queue depth for device
                 if (qd.Value) {


### PR DESCRIPTION
Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>