### PR TITLE
Update timespec definition - no longer available in 5.7 kernels

### DIFF
--- a/source/octf/trace/iotrace_event.h
+++ b/source/octf/trace/iotrace_event.h
@@ -14,6 +14,7 @@ extern "C" {
 #else
 #include <stdint.h>
 #include <time.h>
+#define timespec64 timespec
 #endif
 
 typedef uint64_t log_sid_t;
@@ -197,7 +198,7 @@ struct iotrace_event_file_id {
     /**
      * inode creation date stored in entry
      */
-    struct timespec ctime;
+    struct timespec64 ctime;
 } __attribute__((packed, aligned(8)));
 
 /**


### PR DESCRIPTION
Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>