### PR TITLE
Revert "Remove not used ShellExecutor (#162)"

### DIFF
--- a/source/octf/utils/CMakeLists.txt
+++ b/source/octf/utils/CMakeLists.txt
@@ -31,4 +31,6 @@ PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/CsvParser.h
     ${CMAKE_CURRENT_LIST_DIR}/ProtobufReflection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ProtobufReflection.h
+    ${CMAKE_CURRENT_LIST_DIR}/ShellExecutor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ShellExecutor.h
 )

--- a/source/octf/utils/Exception.h
+++ b/source/octf/utils/Exception.h
@@ -83,13 +83,26 @@ public:
 };
 
 /**
+ * @brief Exception which occurred during shell execution
+ */
+class ShellExecutorException : public octf::Exception {
+public:
+    ShellExecutorException(const std::string &message, const std::string &cmd)
+            : Exception(std::string("Exception occurred during '") + cmd +
+                        "' execution: " + message) {}
+    virtual ~ShellExecutorException() = default;
+};
+
+/**
  * @brief Exception which occurred during file system path traversing
  */
 class MaxPathExceededException : public octf::Exception {
 public:
     MaxPathExceededException(const uint64_t inode)
-            : Exception(std::string("Exceeded maximum path length limit for inode ") +
-                        std::to_string(inode)) {}
+            : Exception(
+                      std::string(
+                              "Exceeded maximum path length limit for inode ") +
+                      std::to_string(inode)) {}
     virtual ~MaxPathExceededException() = default;
 };
 

--- a/source/octf/utils/ShellExecutor.cpp
+++ b/source/octf/utils/ShellExecutor.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include <errno.h>
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <octf/utils/Exception.h>
+#include <octf/utils/ShellExecutor.h>
+
+namespace octf {
+
+std::string ShellExecutor::execute() {
+    std::string result;
+
+    std::string command = m_command;
+    command += " ";
+    command += m_args;
+
+    const char *cmd = command.c_str();
+
+    std::array<char, 128> buffer;
+
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) {
+        throw ShellExecutorException("call to popen() failed", m_command);
+    }
+
+    int read;
+    while ((read = fread(buffer.data(), 1, buffer.size(), pipe.get())) ==
+           static_cast<int>(buffer.size())) {
+        result.append(buffer.data(), read);
+    }
+
+    if (ferror(pipe.get())) {
+        throw ShellExecutorException("could not read from started process",
+                                     m_command);
+    }
+
+    // Not entire buffer was read at the end
+    if (feof(pipe.get()) && read > 0) {
+        result.append(buffer.data(), read);
+    }
+
+    // This should never occur
+    if (!feof(pipe.get())) {
+        throw ShellExecutorException("invalid result of reading from process",
+                                     m_command);
+    }
+
+    // Now check program return code
+    auto pipePtr = pipe.release();
+    int retCode = pclose(pipePtr);
+    if (retCode) {
+        throw ShellExecutorException(std::strerror(errno), m_command);
+    }
+
+    return result;
+}
+
+}  // namespace octf

--- a/source/octf/utils/ShellExecutor.h
+++ b/source/octf/utils/ShellExecutor.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef SOURCE_OCTF_UTILS_SHELLEXECUTOR_H
+#define SOURCE_OCTF_UTILS_SHELLEXECUTOR_H
+
+#include <string>
+#include <octf/utils/Exception.h>
+
+namespace octf {
+
+/**
+ * @brief Class for executing shell commands
+ */
+class ShellExecutor {
+public:
+    ShellExecutor() = default;
+    virtual ~ShellExecutor() = default;
+
+    /**
+     * @brief Executes a command in shell by using popen()
+     *
+     * This effectively creates a pipe, forks and invokes the default shell
+     *
+     * @note Command and arguments are simply concatenated with spaces
+     */
+    std::string execute();
+
+    const std::string &getArgs() const {
+        return m_args;
+    }
+
+    const std::string &getCommand() const {
+        return m_command;
+    }
+
+    void setCommand(const std::string &command) {
+        m_command = command;
+    }
+
+    void setArgs(const std::string &args) {
+        m_args = args;
+    }
+
+private:
+    std::string m_command;
+    std::string m_args;
+};
+
+}  // namespace octf
+
+#endif  // SOURCE_OCTF_UTILS_SHELLEXECUTOR_H


### PR DESCRIPTION
This reverts commit 7d392c3d8aa9df530e25b0e6c4b62c9aec80147a.

Conflicts:
	source/octf/utils/CMakeLists.txt

Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>